### PR TITLE
Listen to other InventoryActions too (v1.1.3)

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -1,7 +1,7 @@
 --- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/Muqsit/InvMenu
 branches:
 - master
-- dev
+- v1.1.3
 projects:
   InvMenu:
     model: virion

--- a/README.md
+++ b/README.md
@@ -80,15 +80,14 @@ $menu->setListener(function(Player $player, Item $itemClickedOn, Item $itemClick
 - **Player `$player` -** *The player responsible for the inventory transaction.*
 - **Item `$itemClickedOn` -** *The item that the player clicked in the GUI.*
 - **Item `$itemClickedWith` -** *The item that the player put in the GUI. This can also be the item that the player clicked `$itemClickedOn` with as players are able to put and takeout items from an inventory in one go.*
-- **SlotChangeAction[] `$inventoryActions` -** *The inventory-sided SlotChangeAction array. You can get the Inventory instance and the inventory slot that was clicked using this.*
-- **SlotChangeAction[] `$playerActions` -** *The player-sided SlotChangeAction array. You can get the player's inventory instance and the player's inventory slot (the slot where the `$itemClickedOn` will go if not cancelled) using this.*
+- **SlotChangeAction `$inventoryActions` -** *The inventory-sided SlotChangeAction. You can get the Inventory instance and the inventory slot that was clicked using this.*
+- **SlotChangeAction[] `$playerActions` -** *The player-sided SlotChangeActions. You can get the player's inventory instance and the player's inventory slot (the slot where the `$itemClickedOn` will go if not cancelled) using this.*
 
 It's not mandatory to specify each and every parameter in the `callable`. You are good to go even by specifying only the parameters you'll be using.
 
 The function is called during `InventoryTransactionEvent` that `InvMenu` handles itself. The function **must** return a `bool` value.
 If the function returns `false`, the `InventoryTransactionEvent` gets cancelled.
 
-**NOTE:** If the player is drag-settings items, `$itemClickedOn` and `$itemClickedWith` probably aren't the best options for you to listen to the transaction. You should instead parse the `SlotChangeAction[]` yourself.<br>
 **NOTE:** If you have your menu set to readonly, then the return value of the function does not matter. `InventoryTransactionEvent` gets cancelled any way.
 
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ $menu->setListener(function(Player $player, Item $itemClickedOn, Item $itemClick
 - **Player `$player` -** *The player responsible for the inventory transaction.*
 - **Item `$itemClickedOn` -** *The item that the player clicked in the GUI.*
 - **Item `$itemClickedWith` -** *The item that the player put in the GUI. This can also be the item that the player clicked `$itemClickedOn` with as players are able to put and takeout items from an inventory in one go.*
-- **SlotChangeAction `$inventoryActions` -** *The inventory-sided SlotChangeAction. You can get the Inventory instance and the inventory slot that was clicked using this.*
-- **SlotChangeAction[] `$playerActions` -** *The player-sided SlotChangeActions. You can get the player's inventory instance and the player's inventory slot (the slot where the `$itemClickedOn` will go if not cancelled) using this.*
+- **SlotChangeAction `$inventoryAction` -** *The inventory-sided SlotChangeAction. You can get the Inventory instance and the inventory slot that was clicked using this.*
+- **InventoryAction[] `$otherActions` -** *The InventoryActions caused outside the InvMenu inventory which affected the InvMenu inventory.*
 
 It's not mandatory to specify each and every parameter in the `callable`. You are good to go even by specifying only the parameters you'll be using.
 

--- a/README.md
+++ b/README.md
@@ -80,18 +80,20 @@ $menu->setListener(function(Player $player, Item $itemClickedOn, Item $itemClick
 - **Player `$player` -** *The player responsible for the inventory transaction.*
 - **Item `$itemClickedOn` -** *The item that the player clicked in the GUI.*
 - **Item `$itemClickedWith` -** *The item that the player put in the GUI. This can also be the item that the player clicked `$itemClickedOn` with as players are able to put and takeout items from an inventory in one go.*
-- **SlotChangeAction `$inventoryAction` -** *The inventory-sided SlotChangeAction. You can get the Inventory instance and the inventory slot that was clicked using this.*
-- **SlotChangeAction `$playerAction` -** *The player-sided SlotChangeAction. You can get the player's inventory instance and the player's inventory slot (the slot where the `$itemClickedOn` will go if not cancelled) using this.*
+- **SlotChangeAction[] `$inventoryActions` -** *The inventory-sided SlotChangeAction array. You can get the Inventory instance and the inventory slot that was clicked using this.*
+- **SlotChangeAction[] `$playerActions` -** *The player-sided SlotChangeAction array. You can get the player's inventory instance and the player's inventory slot (the slot where the `$itemClickedOn` will go if not cancelled) using this.*
 
 It's not mandatory to specify each and every parameter in the `callable`. You are good to go even by specifying only the parameters you'll be using.
 
 The function is called during `InventoryTransactionEvent` that `InvMenu` handles itself. The function **must** return a `bool` value.
 If the function returns `false`, the `InventoryTransactionEvent` gets cancelled.
+
+**NOTE:** If the player is drag-settings items, `$itemClickedOn` and `$itemClickedWith` probably aren't the best options for you to listen to the transaction. You should instead parse the `SlotChangeAction[]` yourself.<br>
 **NOTE:** If you have your menu set to readonly, then the return value of the function does not matter. `InventoryTransactionEvent` gets cancelled any way.
 
 
 ### Sessions
-Now, yeah. InvMenu by default doesn't create a new Inventory instance for every player. In fact, the SAME Inventory is sent to all the players that you `InvMenu::send()` the inventory to.
+InvMenu by default doesn't create a new Inventory instance for every player. In fact, the SAME Inventory is sent to all the players that you `InvMenu::send()` the inventory to.
 You may want to sessionize InvMenu for creating mechanisms like PlayerVaults where every player needs their own inventory.
 You can use `InvMenu::sessionize()` for this.
 ```php

--- a/src/muqsit/invmenu/InvMenuHandler.php
+++ b/src/muqsit/invmenu/InvMenuHandler.php
@@ -61,15 +61,15 @@ class InvMenuHandler implements Listener {
     {
         $tr = $event->getTransaction();
 
-        $inventoryAction = null;
-        $playerAction = null;
+        $inventoryActions = [];
+        $playerActions = [];
         $menu = null;
 
         foreach ($tr->getActions() as $action) {
             if ($action instanceof SlotChangeAction) {
                 $inventory = $action->getInventory();
                 if ($inventory instanceof BaseFakeInventory) {
-                    $inventoryAction = $action;
+                    $inventoryActions[] = $action;
                     $menu = $inventory->getMenu();
                     if ($menu->isReadonly()) {
                         $event->setCancelled();
@@ -78,20 +78,21 @@ class InvMenuHandler implements Listener {
                         return;
                     }
                 } elseif ($inventory instanceof PlayerInventory || $inventory instanceof PlayerCursorInventory) {
-                    $playerAction = $action;
+                    $playerActions[] = $action;
                 }
             }
         }
 
         if (
-            $inventoryAction !== null &&
-            $playerAction !== null &&
+            $menu !== null &&
+            !empty($inventoryActions) &&
+            !empty($playerActions) &&
             !$menu->getListener()(
                 $tr->getSource(),
                 $inventoryAction->getSourceItem(),
                 $playerAction->getSourceItem(),
-                $inventoryAction,
-                $playerAction
+                $inventoryActions,
+                $playerActions
             )
         ) {
             $event->setCancelled();

--- a/src/muqsit/invmenu/InvMenuHandler.php
+++ b/src/muqsit/invmenu/InvMenuHandler.php
@@ -24,7 +24,7 @@ use muqsit\invmenu\inventories\BaseFakeInventory;
 use pocketmine\event\inventory\InventoryTransactionEvent;
 use pocketmine\event\Listener;
 use pocketmine\inventory\{PlayerCursorInventory, PlayerInventory};
-use pocketmine\inventory\transaction\action\SlotChangeAction;
+use pocketmine\inventory\transaction\action\{DropItemAction, SlotChangeAction};
 use pocketmine\plugin\PluginBase;
 
 class InvMenuHandler implements Listener {
@@ -86,6 +86,8 @@ class InvMenuHandler implements Listener {
                 } else {
                     $hasOtherActions = true;
                 }
+            } elseif ($action instanceof DropItemAction) {
+                $playerActions[] = $action;
             }
         }
 

--- a/src/muqsit/invmenu/InvMenuHandler.php
+++ b/src/muqsit/invmenu/InvMenuHandler.php
@@ -23,8 +23,7 @@ use muqsit\invmenu\inventories\BaseFakeInventory;
 
 use pocketmine\event\inventory\InventoryTransactionEvent;
 use pocketmine\event\Listener;
-use pocketmine\inventory\{PlayerCursorInventory, PlayerInventory};
-use pocketmine\inventory\transaction\action\{DropItemAction, SlotChangeAction};
+use pocketmine\inventory\transaction\action\SlotChangeAction;
 use pocketmine\plugin\PluginBase;
 
 class InvMenuHandler implements Listener {
@@ -62,10 +61,9 @@ class InvMenuHandler implements Listener {
         $tr = $event->getTransaction();
 
         $inventoryActions = [];
-        $playerActions = [];
+        $otherActions = [];
 
         $menu = null;
-        $hasOtherActions = false;
 
         foreach ($tr->getActions() as $action) {
             if ($action instanceof SlotChangeAction) {
@@ -81,25 +79,18 @@ class InvMenuHandler implements Listener {
                     if (!$menu->isListenable()) {
                         return;
                     }
-                } elseif ($inventory instanceof PlayerInventory || $inventory instanceof PlayerCursorInventory) {
-                    $playerActions[] = $action;
-                } else {
-                    $hasOtherActions = true;
-                }
-            } elseif ($action instanceof DropItemAction) {
-                $playerActions[] = $action;
-            }
-        }
 
-        if ($menu !== null && $hasOtherActions) { //this probably needs an improvement
-            $event->setCancelled();
-            return;
+                    continue;
+                }
+            }
+
+            $otherActions[] = $action;
         }
 
         if (
             $menu !== null &&
             !empty($inventoryActions) &&
-            !empty($playerActions)
+            !empty($otherActions)
         ) {
             $listener = $menu->getListener();
             foreach ($inventoryActions as $inventoryAction) {
@@ -108,7 +99,7 @@ class InvMenuHandler implements Listener {
                     $inventoryAction->getSourceItem(),
                     $inventoryAction->getTargetItem(),
                     $inventoryAction,
-                    $playerActions
+                    $otherActions
                 )) {
                     $event->setCancelled();
                     return;

--- a/virion.yml
+++ b/virion.yml
@@ -1,5 +1,5 @@
 name: InvMenu
 antigen: muqsit\invmenu
 api: 3.0.0
-version: 1.1.2
+version: 1.1.3
 author: Muqsit


### PR DESCRIPTION
## Backwards Incompatibility
This is a backwards incompatible change, that is if you are calling the last parameter of InvMenu's listener.
The new listener parameters are:
```php
/**
 * @param Player $player
 * @param Item $itemClickedOn
 * @param Item $itemClickedWith
 * @param SlotChangeAction $inventoryAction
 * @param InventoryAction[] $otherActions
 *
 * @return bool
 */
public function listen(Player $player, Item $itemClickedOn, Item $itemClickedWith, SlotChangeAction $inventoryAction, array $otherActions) : bool;
```

Previously, InvMenu would listen ONLY to simple drag-drop transactions which consisted of exactly two InventoryActions provided the InventoryActions had different inventory classes.

From this change onwards, the InvMenu listener will be called for each item that was drag-set. In fact, it will listen to each and every inventory action involving a player and an InvMenu inventory. Also, cancelling the listener (i.e `return false;`) will cancel transaction of ALL the items that were drag-set.

The `$otherActions` array contains other `InventoryAction` instances that aren't an instanceof `SlotChangeAction` or the `SlotChangeAction::getInventory()` is not an instanceof `BaseFakeInventory`. In other words, non-invmenu-inventory actions.

## Changes
InvMenu now listens to ALL inventory actions caused by players. This includes dropping items out of chest and drag-setting items.