### PR TITLE
Fixes inventory crash caused by ContainerClosePacket.

### DIFF
--- a/src/muqsit/invmenu/inventory/InvMenuInventory.php
+++ b/src/muqsit/invmenu/inventory/InvMenuInventory.php
@@ -71,7 +71,9 @@ class InvMenuInventory extends ContainerInventory{
 	public function closeInventory(Player $who){
 		if(isset($this->viewers[spl_object_hash($who)])){
 			/** @noinspection NullPointerExceptionInspection */
-			if(($menu = PlayerManager::getNonNullable($who)->getCurrentMenu()) !== null) $menu->onClose($who);
+			$session = PlayerManager::get($who);
+			if($session === null) return;
+			if(($menu = $session->getCurrentMenu()) !== null) $menu->onClose($who);
 		}
 	}
 }

--- a/src/muqsit/invmenu/inventory/InvMenuInventory.php
+++ b/src/muqsit/invmenu/inventory/InvMenuInventory.php
@@ -62,9 +62,16 @@ class InvMenuInventory extends ContainerInventory{
 
 	public function onClose(Player $who) : void{
 		if(isset($this->viewers[spl_object_hash($who)])){
-			parent::onClose($who);
+			$this->closeInventory($who);
 			/** @noinspection NullPointerExceptionInspection */
-			PlayerManager::getNonNullable($who)->getCurrentMenu()->onClose($who);
+			parent::onClose($who);
+		}
+	}
+
+	public function closeInventory(Player $who){
+		if(isset($this->viewers[spl_object_hash($who)])){
+			/** @noinspection NullPointerExceptionInspection */
+			if(($menu = PlayerManager::getNonNullable($who)->getCurrentMenu()) !== null) $menu->onClose($who);
 		}
 	}
 }

--- a/src/muqsit/invmenu/metadata/SingleBlockMenuMetadata.php
+++ b/src/muqsit/invmenu/metadata/SingleBlockMenuMetadata.php
@@ -101,7 +101,7 @@ class SingleBlockMenuMetadata extends MenuMetadata{
 			$packet->y = $pos->y;
 			$packet->z = $pos->z;
 			$packet->blockRuntimeId = $level->getBlockAt($pos->x, $pos->y, $pos->z)->getRuntimeId();
-			$packet->flags = UpdateBlockPacket::FLAG_NETWORK;
+			$packet->flags = UpdateBlockPacket::FLAG_ALL_PRIORITY;
 			$player->sendDataPacket($packet);
 		}
 	}

--- a/src/muqsit/invmenu/session/PlayerSession.php
+++ b/src/muqsit/invmenu/session/PlayerSession.php
@@ -65,7 +65,7 @@ class PlayerSession{
 	public function removeWindow() : void{
 		$window = $this->player->getWindow($this->current_window_id);
 		if($window instanceof InvMenuInventory){
-			$this->player->removeWindow($window);
+			$window->closeInventory($this->player);
 			$this->network->wait(static function(bool $success) : void{});
 		}
 		$this->current_window_id = ContainerIds::NONE;


### PR DESCRIPTION
**ContainerClosePacket should never be called except the client has sent the packet**. 

This idea comes into my head when I tried to remove a chest block, I noticed it will always work compared to the traditional `Player::removeWindow`. I assume that the chest must be invalid first in order to close the inventory.

## What?
To clarify this situation, you cannot close this inventory by calling `InvMenuInventory::onClose` or `InvMenuInventory::close` or even `Player::removeWindow`. Calling `closeInventory()` will ensure that the chest has successfully being removed and the client will send the ContainerClosePacket to the server. 

### Why?
The way how this works is, by removing the chest before `onClose`. The client will send a ContainerClosePacket back to the server and the server will handles the packet. The server will however calls `onClose()` and the packet confirming the container being closed will be sent. Closing an inventory should be handled client-sided and not server-sided (Under my observation). 
This is more like a hack rather than a fix.

Here is a playthrough of my AuctionHouse plugin with this version of InvMenu.
https://streamable.com/hk8tcz