### PR TITLE
Work around for 1.16 clients crashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,12 @@ void callback(Player $player, InvMenuInventory $inventory);
 ```
 To forcefully close or remove the menu from a player, you can use
 ```php
+/** @var InvMenu $menu */
 /** @var Player $player */
-$player->removeCurrentWindow();
+$menu->remove($player);
 ```
+From 1.16, it is required to use ``InvMenu->remove()`` because the client will crash when using ``Player->removeWindow()``.
+
 **NOTE:** Inventory instances aren't persistent. They get destroyed as soon as the player closes the inventory or quits the server. If you want inventory contents to persist, you may listen to inventory close triggers and store the inventory contents.
 
 ### Writing a custom inventory class

--- a/src/muqsit/invmenu/InvMenu.php
+++ b/src/muqsit/invmenu/InvMenu.php
@@ -163,4 +163,8 @@ abstract class InvMenu implements MenuIds{
 
 		PlayerManager::getNonNullable($player)->removeCurrentMenu();
 	}
+
+	public function remove(Player $player) : void{
+	    PlayerManager::getNonNullable($player)->removeWindow();
+    }
 }

--- a/src/muqsit/invmenu/session/PlayerSession.php
+++ b/src/muqsit/invmenu/session/PlayerSession.php
@@ -65,7 +65,7 @@ class PlayerSession{
 	public function removeWindow() : void{
 		$window = $this->player->getWindow($this->current_window_id);
 		if($window instanceof InvMenuInventory){
-			$this->player->removeWindow($window);
+            $this->current_menu->getType()->removeGraphic($this->player, $this->menu_extradata);
 			$this->network->wait(static function(bool $success) : void{});
 		}
 		$this->current_window_id = ContainerIds::NONE;
@@ -135,7 +135,6 @@ class PlayerSession{
 	 */
 	public function removeCurrentMenu() : bool{
 		if($this->current_menu !== null){
-			$this->current_menu->getType()->removeGraphic($this->player, $this->menu_extradata);
 			$this->menu_extradata->reset();
 			return $this->setCurrentMenu(null);
 		}


### PR DESCRIPTION
Using ``InvMenu->remove()`` will close the inventory without crashing the 1.16 client.

Test plugin:
```php
/**
 * @name InvMenuTest
 * @main twisted\invmenutest\InvMenuTest
 * @version 1.0.0
 * @api 3.0.0
 */
namespace twisted\invmenutest {

    use muqsit\invmenu\InvMenu;
    use muqsit\invmenu\InvMenuHandler;
    use pocketmine\event\block\BlockBreakEvent;
    use pocketmine\event\Listener;
    use pocketmine\inventory\transaction\action\SlotChangeAction;
    use pocketmine\item\Item;
    use pocketmine\Player;
    use pocketmine\plugin\PluginBase;

    class InvMenuTest extends PluginBase implements Listener
    {

        public function onEnable(): void
        {
            if (!InvMenuHandler::isRegistered()) {
                InvMenuHandler::register($this);
            }

            $this->getServer()->getPluginManager()->registerEvents($this, $this);
        }

        public function onBlockBreak(BlockBreakEvent $event): void
        {
            $menu = InvMenu::create(InvMenu::TYPE_HOPPER);
            $menu->setName("Break Confirmation");
            $menu->setListener(static function (Player $player, Item $itemClicked, Item $itemClickedWith, SlotChangeAction $action) use ($menu) : bool {
                if ($action->getSlot() !== 2) {
                    $player->sendMessage("You just wasted time in your life this actually doesn't confirm anything");
                    $menu->remove($player);
                }

                return false;
            });
            $menu->setInventoryCloseListener(static function (Player $player): void {
                $player->sendMessage("You have closed the inventory");
            });
            $menu->getInventory()->setContents([
                Item::get(Item::STAINED_GLASS_PANE, 13)->setCustomName("Confirm"),
                Item::get(Item::STAINED_GLASS_PANE, 13)->setCustomName("Confirm"),
                $event->getBlock()->getPickedItem(),
                Item::get(Item::STAINED_GLASS_PANE, 14)->setCustomName("Cancel"),
                Item::get(Item::STAINED_GLASS_PANE, 14)->setCustomName("Cancel"),
            ]);
            $menu->send($event->getPlayer());
        }
    }
}
```