### PR TITLE
Compliant Solution

### DIFF
--- a/src/muqsit/invmenu/InvMenuEventHandler.php
+++ b/src/muqsit/invmenu/InvMenuEventHandler.php
@@ -98,7 +98,7 @@ final class InvMenuEventHandler implements Listener{
 					}
 				}
 			}
-			if(count($network_stack_callbacks) > 0){
+			if(!empty($network_stack_callbacks)){
 				$player_instance->getNetwork()->wait(static function(bool $success) use($player, $network_stack_callbacks) : void{
 					if($success){
 						foreach($network_stack_callbacks as $callback){


### PR DESCRIPTION
Using count() to test for emptiness works, but using empty() makes the code more readable and can be more performant