### PR TITLE
fix(player): quickfix menu

### DIFF
--- a/src/muqsit/invmenu/session/network/PlayerNetwork.php
+++ b/src/muqsit/invmenu/session/network/PlayerNetwork.php
@@ -172,7 +172,7 @@ final class PlayerNetwork{
 	}
 
 	public function notify(int $timestamp) : void{
-		if($this->current !== null && $timestamp === $this->current->timestamp){
+		if($this->current !== null && $timestamp === $this->current->timestamp * 1000000){
 			$this->processCurrent(true);
 		}
 	}


### PR DESCRIPTION
Fix the menu dont send... Quickfix: multitply  1000000 for the stored timestamp 