### PR TITLE
Fix PlayStation user canot open UI bug

### DIFF
--- a/src/muqsit/invmenu/session/network/handler/PlayerNetworkHandlerRegistry.php
+++ b/src/muqsit/invmenu/session/network/handler/PlayerNetworkHandlerRegistry.php
@@ -23,7 +23,7 @@ final class PlayerNetworkHandlerRegistry{
 		}));
 		$this->register(DeviceOS::PLAYSTATION, new ClosurePlayerNetworkHandler(static function(Closure $then) : NetworkStackLatencyEntry{
 			$timestamp = mt_rand();
-			return new NetworkStackLatencyEntry($timestamp, $then, $timestamp * 1000);
+			return new NetworkStackLatencyEntry($timestamp * 1000000, $then, $timestamp * 1000);
 		}));
 	}
 


### PR DESCRIPTION
Fixes #219 (and originally #216)
Since 1.20.10 Mojang changed weird stuffs. Muqsit fixed this to most of the platforms and after a little bit of testing it seems that the same fix also works for PlayStation users.

Here is a PR as requested in https://github.com/Muqsit/InvMenu/pull/218#issuecomment-1637004185